### PR TITLE
Rename MCP server from 'credyt' to 'api'

### DIFF
--- a/credyt-plugin/.mcp.json
+++ b/credyt-plugin/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "credyt": {
+    "api": {
       "command": "npx",
       "args": [
         "mcp-remote",

--- a/credyt-plugin/commands/init.md
+++ b/credyt-plugin/commands/init.md
@@ -8,7 +8,7 @@ Get the user connected to Credyt so they can use `/credyt:setup`, `/credyt:verif
 
 ## Step 1: Check if already connected
 
-Try calling `credyt:list_assets`. If it works, the MCP is connected and authenticated.
+Try calling `api:list_assets`. If it works, the MCP is connected and authenticated.
 
 If connected, tell the user:
 
@@ -54,7 +54,7 @@ The plugin bundles the MCP server config, but the user needs to set their API ke
 
 ## Step 4: Verify the connection
 
-After restart, try `credyt:list_assets` again.
+After restart, try `api:list_assets` again.
 
 If it works:
 

--- a/credyt-plugin/skills/setup/SKILL.md
+++ b/credyt-plugin/skills/setup/SKILL.md
@@ -9,7 +9,7 @@ Guide the user through understanding their billing model, then configure everyth
 
 ## First: Check what already exists
 
-Before jumping into discovery, check the current state by calling `credyt:list_assets` and `credyt:list_products`.
+Before jumping into discovery, check the current state by calling `api:list_assets` and `api:list_products`.
 
 If they already have products configured, acknowledge what's there:
 
@@ -86,19 +86,19 @@ Walk the user through each step. Explain what you're creating in plain terms and
 
 Only if they chose a custom currency. This must be created before any products that use it.
 
-Use `credyt:create_asset`. Before creating, explain the conversion clearly:
+Use `api:create_asset`. Before creating, explain the conversion clearly:
 
 > "So if 1 credit = $0.05, that means $1 gets you 20 credits. A user topping up $10 would get 200 credits. Does that feel right?"
 
-**After creating**, use `credyt:quote_asset` to verify the conversion. Quote how many units $1, $10, and $50 would buy:
+**After creating**, use `api:quote_asset` to verify the conversion. Quote how many units $1, $10, and $50 would buy:
 
 > "Let me verify that... ✓ $1 buys 20 credits, $10 buys 200, $50 buys 1,000. Does that look right?"
 
-If the conversion is wrong, use `credyt:add_asset_rate` to correct it and re-quote.
+If the conversion is wrong, use `api:add_asset_rate` to correct it and re-quote.
 
 ### Create products with pricing
 
-Use `credyt:create_product` for each billable activity. Walk them through what you're setting up:
+Use `api:create_product` for each billable activity. Walk them through what you're setting up:
 
 > "I'm going to create a product called 'Image Generation' that tracks every time a user generates an image and charges 10 credits. Here's what that means..."
 
@@ -112,11 +112,11 @@ Explain key fields in plain terms:
 - **Usage type**: Per occurrence ("unit") or based on a quantity like tokens ("volume")
 - **Pricing**: How much each event costs
 
-**After creating every product**, use `credyt:simulate_usage` to validate. Construct a sample event matching what would happen in their app:
+**After creating every product**, use `api:simulate_usage` to validate. Construct a sample event matching what would happen in their app:
 
 > "Let me test this — one image generation should cost 10 credits... ✓ Confirmed: 10 credits deducted, that's $0.50. Does that match what you expected?"
 
-If the simulation doesn't match, create a new product version with `credyt:create_product_version` using the corrected pricing and re-simulate until it's right.
+If the simulation doesn't match, create a new product version with `api:create_product_version` using the corrected pricing and re-simulate until it's right.
 
 ### Set up cost tracking (prompt for this)
 
@@ -124,7 +124,7 @@ Before verification, ask if they want to track what activities cost them:
 
 > "Do you want to track what each activity actually costs you? For example, if generating an image costs you $0.03 in API fees, Credyt can record that alongside the revenue so you can see your margins in real time."
 
-**If yes**, create vendors with `credyt:create_vendor` for each service provider (OpenAI, Anthropic, AWS, etc.):
+**If yes**, create vendors with `api:create_vendor` for each service provider (OpenAI, Anthropic, AWS, etc.):
 
 > "You mentioned you're using OpenAI for image generation — I'll register them as a cost provider so we can track those costs."
 
@@ -142,7 +142,7 @@ Run the verification against each product that was created or modified in this s
 
 ### Step 1: Create a test customer
 
-Use `credyt:create_customer` with:
+Use `api:create_customer` with:
 - Name: "Verification Test Customer"
 - External ID: a unique value like "verify_test_{timestamp}"
 - Subscribe to the product being tested
@@ -151,21 +151,21 @@ Record the customer ID.
 
 ### Step 2: Check starting balance
 
-Use `credyt:get_wallet` to confirm the wallet exists and the balance is zero.
+Use `api:get_wallet` to confirm the wallet exists and the balance is zero.
 
 ### Step 3: Fund the wallet
 
-Use `credyt:create_adjustment` to add test funds in the same asset the product charges in. Add enough to cover a few test events (e.g., $10.00 USD or 200 credits).
+Use `api:create_adjustment` to add test funds in the same asset the product charges in. Add enough to cover a few test events (e.g., $10.00 USD or 200 credits).
 
 - `reason`: "gift"
 - `description`: "Verification test funding"
 - `transaction_id`: A unique UUID
 
-Use `credyt:get_wallet` to confirm the balance updated.
+Use `api:get_wallet` to confirm the balance updated.
 
 ### Step 4: Send a test usage event
 
-Use `credyt:submit_events` to send one realistic event matching the product's configuration:
+Use `api:submit_events` to send one realistic event matching the product's configuration:
 
 - For **unit-based** products: a single event with the correct event_type
 - For **volume-based** products: include the volume field with a test quantity
@@ -175,11 +175,11 @@ Use a unique UUID for the event ID. Record it.
 
 ### Step 5: Verify fees were generated
 
-Use `credyt:get_event` with the event ID. Check that fees were generated and the amount matches the expected price.
+Use `api:get_event` with the event ID. Check that fees were generated and the amount matches the expected price.
 
 ### Step 6: Verify balance changed
 
-Use `credyt:get_wallet` to confirm the balance decreased by exactly the expected fee amount.
+Use `api:get_wallet` to confirm the balance decreased by exactly the expected fee amount.
 
 ### Report results
 

--- a/credyt-plugin/skills/verify/SKILL.md
+++ b/credyt-plugin/skills/verify/SKILL.md
@@ -13,11 +13,11 @@ This is the standalone version of the verification that runs automatically at th
 
 If the user specified a product (e.g., `/credyt:verify image_gen_std`), use that. The `$ARGUMENTS` value is the product code or name.
 
-If no product was specified, call `credyt:list_products` and ask which one to test:
+If no product was specified, call `api:list_products` and ask which one to test:
 
 > "Which product do you want to verify? Here's what you have set up: [list products]"
 
-Once a product is identified, retrieve its details with `credyt:get_product` and determine:
+Once a product is identified, retrieve its details with `api:get_product` and determine:
 - The event type it expects
 - The usage type (unit, volume, or both)
 - The asset it charges in (USD, credits, etc.)
@@ -34,7 +34,7 @@ Execute each step and track pass/fail. If any step fails, stop and help troubles
 
 ### Step 1: Create a test customer
 
-Use `credyt:create_customer` with:
+Use `api:create_customer` with:
 - Name: "Verification Test Customer"
 - External ID: something unique like "verify_test_{timestamp}"
 - Subscribe to the product being tested
@@ -46,20 +46,20 @@ Record the customer ID for subsequent steps.
 
 ### Step 2: Check starting balance
 
-Use `credyt:get_wallet` to show the initial wallet state.
+Use `api:get_wallet` to show the initial wallet state.
 
 **Pass**: Wallet exists (it's created automatically with the subscription). Balance is $0.00 or empty.
 **Fail**: No wallet found — check subscription status.
 
 ### Step 3: Fund the wallet
 
-Use `credyt:create_adjustment` to add test funds. Use the same asset the product charges in. Add enough to cover a few test events (e.g., $10.00 USD or 200 credits).
+Use `api:create_adjustment` to add test funds. Use the same asset the product charges in. Add enough to cover a few test events (e.g., $10.00 USD or 200 credits).
 
 - `reason`: "gift"
 - `description`: "Verification test funding"
 - `transaction_id`: Generate a unique UUID
 
-Use `credyt:get_wallet` to confirm the balance updated.
+Use `api:get_wallet` to confirm the balance updated.
 
 **Pass**: Balance matches the amount added.
 **Fail**: Check the asset code matches what the product expects.
@@ -68,7 +68,7 @@ Record the balance after funding.
 
 ### Step 4: Send a test usage event
 
-Use `credyt:submit_events` to send one realistic event. Construct it to match what the product expects:
+Use `api:submit_events` to send one realistic event. Construct it to match what the product expects:
 
 - For **unit-based** products: send a single event with the correct event_type
 - For **volume-based** products: include the volume field with a test quantity (e.g., `{ "total_tokens": 1000 }`)
@@ -83,7 +83,7 @@ Record the event ID.
 
 ### Step 5: Verify fees were generated
 
-Use `credyt:get_event` with the event ID to retrieve the event details. Check that:
+Use `api:get_event` with the event ID to retrieve the event details. Check that:
 - Fees were generated (not empty)
 - The fee amount matches the expected price
 
@@ -94,7 +94,7 @@ Record the fee amount.
 
 ### Step 6: Verify balance changed
 
-Use `credyt:get_wallet` to check the balance after billing.
+Use `api:get_wallet` to check the balance after billing.
 
 Calculate: starting balance - fee amount = expected new balance.
 


### PR DESCRIPTION
## Summary
This PR updates all references to the MCP server from `credyt` to `api` across the plugin documentation and configuration files. This is a naming convention change to make the server identifier more generic and aligned with the actual API interface.

## Key Changes
- Updated `.mcp.json` configuration to rename the MCP server from `credyt` to `api`
- Updated all skill documentation files (`setup/SKILL.md` and `verify/SKILL.md`) to reference `api:*` commands instead of `credyt:*` commands
- Updated command documentation (`commands/init.md`) to use the new `api:list_assets` naming convention
- All API function calls now use the `api:` prefix (e.g., `api:create_asset`, `api:submit_events`, `api:get_wallet`, etc.)

## Implementation Details
This is a straightforward naming refactor with no functional changes to the underlying API or behavior. The change affects:
- MCP server configuration identifier
- All command references in user-facing documentation
- All example code snippets and instructions throughout the skill guides

The actual API functionality remains unchanged; only the namespace/prefix used to invoke these commands has been updated.

https://claude.ai/code/session_01Q8ygix5Gi11yf6caQ7vnGk