### PR TITLE
Remove placeholder env default from .mcp.json

### DIFF
--- a/credyt-plugin/.mcp.json
+++ b/credyt-plugin/.mcp.json
@@ -7,10 +7,7 @@
         "https://mcp.credyt.ai",
         "--header",
         "Authorization:${CREDYT_API_KEY}"
-      ],
-      "env": {
-        "CREDYT_API_KEY": "Bearer your_api_key"
-      }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove the `env` block with placeholder `CREDYT_API_KEY` default from `.mcp.json`
- Without the default, Claude Code fails to parse the config if the key isn't set, giving users a clear error instead of silently starting the MCP server with an invalid key

## Test plan
- [ ] Verify plugin fails with a clear error when `CREDYT_API_KEY` is not set
- [ ] Verify plugin works normally when `CREDYT_API_KEY` is set via settings or shell env

🤖 Generated with [Claude Code](https://claude.com/claude-code)