### PR TITLE
Prevent API key exposure in init command

### DIFF
--- a/credyt-plugin/.claude-plugin/plugin.json
+++ b/credyt-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "credyt",
   "description": "Set up and integrate Credyt — real-time billing infrastructure for AI products. Guides you through pricing discovery, product configuration, verification, and code integration.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Credyt"
   },

--- a/credyt-plugin/commands/init.md
+++ b/credyt-plugin/commands/init.md
@@ -8,7 +8,13 @@ Get the user connected to Credyt so they can use `/credyt:setup`, `/credyt:verif
 
 ## Step 1: Check for API key in the environment
 
-Check if `CREDYT_API_KEY` is set in the current environment.
+Check if `CREDYT_API_KEY` is set in the current environment by running:
+
+```bash
+test -n "$CREDYT_API_KEY" && echo "set" || echo "not set"
+```
+
+**Never** echo or print the actual API key value to the terminal.
 
 If it **is** set, skip directly to **Step 3: Verify the MCP connection**.
 
@@ -100,8 +106,10 @@ If the MCP call failed or the tool isn't available, help the user troubleshoot:
 
 > "The MCP connection failed. A few things to check:
 >
-> - Is `CREDYT_API_KEY` set in your environment? Run `echo $CREDYT_API_KEY` to verify.
-> - Does the value start with `Bearer key_...`? The `Bearer ` prefix is required.
 > - Have you restarted Claude Code since setting the variable?
+> - Check that `CREDYT_API_KEY` is present in your settings file (`~/.claude/settings.json` or `.claude/settings.local.json`) under the `env` block.
+> - The value should be in the format `Bearer key_...` — the `Bearer ` prefix is required.
 >
-> Once you've checked these, run `/credyt:init` again."
+> Would you like me to check the settings files for you, or would you prefer to re-enter your API key?"
+
+**Never** echo or print the API key value to the terminal. If the user wants to re-enter their key, go back to **Step 2a**. If they want you to check the files, read the relevant settings file and confirm whether `CREDYT_API_KEY` is present and correctly formatted (without outputting the full key — just confirm the format looks right, e.g. "starts with `Bearer key_` and is N characters long").


### PR DESCRIPTION
## Summary
- Check env var presence with `test -n` instead of echoing the value
- Replace `echo $CREDYT_API_KEY` troubleshooting advice with guidance to inspect settings files directly
- Offer to re-enter the key or check files on auth failure, never printing the key
- Bump plugin version to 1.0.1

## Test plan
- [ ] Run `/credyt:init` with key set — confirm key is not printed to terminal
- [ ] Run `/credyt:init` with MCP connection failure — confirm troubleshooting doesn't suggest echoing the key

🤖 Generated with [Claude Code](https://claude.com/claude-code)