### PR TITLE
docs: move Claude Desktop into its own top-level section

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          branch_name_template: "{{prefix}}{{entityType}}-{{entityNumber}}-{{description}}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,14 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Credyt AI Skills — skill definitions for setting up, verifying, and integrating [Credyt](https://credyt.ai) real-time billing infrastructure into AI products. Skills work with any AI agent via skills.sh, and are also bundled as a Claude Code plugin with MCP auto-configuration.
+Credyt AI Skills — skill definitions for setting up, verifying, and integrating [Credyt](https://credyt.ai) real-time monetization infrastructure into AI products. Skills work with any AI agent via skills.sh, and are also bundled as a Claude Code plugin with MCP auto-configuration.
 
 ## Repository Structure
 
 This is a **pure skill scaffold** — no build system, no tests, no application code. The repo contains only skill definitions (Markdown files), plugin metadata, and MCP configuration.
 
 - `skills/` — Shared skill definitions (the single source of truth):
-  - `setup/SKILL.md` — Guided billing model discovery and product configuration
+  - `setup/SKILL.md` — Guided pricing model discovery and product configuration
   - `verify/SKILL.md` — End-to-end billing cycle test
   - `integrate/SKILL.md` — Wire Credyt into application code
 - `claude-plugins/credyt/` — Claude Code plugin:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Credyt AI Skills
 
-Set up and integrate [Credyt](https://credyt.ai) — real-time billing infrastructure for AI products — directly from your AI agent. Three skills guide you from first configuration through production integration.
+Set up and integrate [Credyt](https://credyt.ai) — real-time monetization infrastructure for AI products — directly from your AI agent. Three skills guide you from first configuration through production integration.
 
 ## Quick install (any AI agent)
 
@@ -20,11 +20,11 @@ The skills use the Credyt MCP server. Connect it in your tool at `https://mcp.cr
 
 ### Available skills
 
-| Skill | What it does |
-|-------|--------------|
-| `setup` | Discovers your billing model, configures products, assets, and pricing via MCP, and verifies the full billing cycle |
-| `verify` | Tests the billing cycle end-to-end for a specific product |
-| `integrate` | Wires Credyt billing into your application code |
+| Skill       | What it does                                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------------- |
+| `setup`     | Discovers your pricing model, configures products, assets, and pricing via MCP, and verifies the full billing cycle |
+| `verify`    | Tests the billing cycle end-to-end for a specific product                                                           |
+| `integrate` | Wires Credyt billing into your application code                                                                     |
 
 ---
 
@@ -43,12 +43,12 @@ The skills are identical — the plugin adds MCP auto-configuration and a guided
 
 The plugin also connects to the **Credyt MCP server** (`mcp.credyt.ai`), which exposes the Credyt API as tools Claude can call directly — creating products, sending events, checking wallets, and more.
 
-| Type | Name | What it does |
-|------|------|--------------|
-| Command | `/credyt:init` | Gets you connected to Credyt. Creates an account, configures the API key, and verifies the MCP connection. Run this first. |
-| Skill | `/credyt:setup` | Discovers your billing model through a guided conversation, then configures products, assets, and pricing in Credyt via MCP. Runs a full end-to-end billing cycle verification automatically. |
-| Skill | `/credyt:verify` | Tests the full billing cycle for a specific product — creates a test customer, funds their wallet, sends a usage event, and confirms the fee was charged correctly. Use this after making changes or to troubleshoot. |
-| Skill | `/credyt:integrate` | Wires Credyt into your application code. Adds customer creation at signup, usage event tracking, balance checks, cost tracking, billing portal links, and balance display. |
+| Type    | Name                | What it does                                                                                                                                                                                                          |
+| ------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Command | `/credyt:init`      | Gets you connected to Credyt. Creates an account, configures the API key, and verifies the MCP connection. Run this first.                                                                                            |
+| Skill   | `/credyt:setup`     | Discovers your billing model through a guided conversation, then configures products, assets, and pricing in Credyt via MCP. Runs a full end-to-end billing cycle verification automatically.                         |
+| Skill   | `/credyt:verify`    | Tests the full billing cycle for a specific product — creates a test customer, funds their wallet, sends a usage event, and confirms the fee was charged correctly. Use this after making changes or to troubleshoot. |
+| Skill   | `/credyt:integrate` | Wires Credyt into your application code. Adds customer creation at signup, usage event tracking, balance checks, cost tracking, billing portal links, and balance display.                                            |
 
 ### Installation
 
@@ -99,29 +99,6 @@ To persist across sessions, add the line to your shell profile and run `source ~
 
 </details>
 
-**Claude Desktop** — open Settings → Developer → Edit config and replace `your_api_key` in the Credyt entry:
-
-```json
-{
-  "mcpServers": {
-    "credyt": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.credyt.ai",
-        "--header",
-        "Authorization:${CREDYT_API_KEY}"
-      ],
-      "env": {
-        "CREDYT_API_KEY": "Bearer sk_your_api_key_here"
-      }
-    }
-  }
-}
-```
-
-Restart Claude Desktop after saving.
-
 #### 3. Install the plugin
 
 **From GitHub** — run these two commands inside Claude Code:
@@ -167,6 +144,39 @@ Wire billing into your app code:
 ```
 /credyt:integrate
 ```
+
+---
+
+## Claude Desktop
+
+Claude Desktop connects to the Credyt MCP server directly — no plugin system, no auto-configuration. It works well for managing an existing Credyt setup conversationally: querying recent activity, making ad-hoc price changes, viewing customer and wallet information, and similar tasks.
+
+The guided skills (`setup`, `verify`, `integrate`) can also be used in Claude Desktop, but they must be uploaded manually — attach the relevant `SKILL.md` file or paste its contents into the conversation.
+
+### Connect the MCP server
+
+Open Settings → Developer → Edit config and add the Credyt entry:
+
+```json
+{
+  "mcpServers": {
+    "credyt": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.credyt.ai",
+        "--header",
+        "Authorization:${CREDYT_API_KEY}"
+      ],
+      "env": {
+        "CREDYT_API_KEY": "Bearer sk_your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving.
 
 ---
 


### PR DESCRIPTION
## What changed

Moved the Claude Desktop MCP configuration out of the Claude Code plugin installation steps and into a new standalone `## Claude Desktop` section at the end of the README.

Claude Desktop doesn't use the plugin system — it has no slash commands, no auto-install, and no `/credyt:init`. Embedding its config inside the plugin install flow implied a shared experience that doesn't exist.

The new section:
- Clarifies that Desktop is MCP-only, manual configuration
- Frames its best use case: ad-hoc management of an existing Credyt setup (querying activity, price changes, customer info)
- Notes that the guided skills can be used but must be uploaded manually
- Keeps the same MCP config JSON and restart instructions

Also includes minor working-tree changes: `billing` → `monetization` in the README and CLAUDE.md intro, aligned table column formatting, and a `branch_name_template` addition to the GitHub Actions workflow.

## How to test

1. Clone and open `README.md`
2. Confirm "Claude Desktop" no longer appears under the Claude Code plugin installation steps
3. Confirm the new `## Claude Desktop` section appears after `## Claude Code plugin`, before `## Resources`
4. Confirm the section accurately describes manual MCP setup and the limitations vs. the plugin

## Trade-offs

The Desktop section doesn't include a full getting-started flow (there's no equivalent of `/credyt:init`). That's intentional — the guided workflow lives in Claude Code. A future improvement could link to the skills files for users who want to paste them manually.