### PR TITLE
feat: update entitlements schema and fixed fee subscription redirects

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "credyt",
   "description": "Set up and integrate Credyt — real-time billing infrastructure for AI products. Guides you through pricing discovery, product configuration, verification, and code integration.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Credyt"
   },

--- a/claude-plugins/credyt/.claude-plugin/plugin.json
+++ b/claude-plugins/credyt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "credyt",
   "description": "Set up and integrate Credyt — real-time billing infrastructure for AI products. Guides you through pricing discovery, product configuration, verification, and code integration.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Credyt"
   },

--- a/skills/billing-integration/SKILL.md
+++ b/skills/billing-integration/SKILL.md
@@ -45,9 +45,15 @@ Key points:
 
 If the product uses a recurring fixed fee (e.g. $20/month), the customer must pay upfront before their subscription activates. In this case the API returns a `pending` status rather than activating immediately.
 
+Set `return_url`, `failure_url`, and `redirect_to` on the subscription creation call so Credyt knows where to send the customer after payment — before you ever redirect them anywhere:
+
+- `return_url` — where to send the customer after successful payment (e.g. `https://yourapp.com/account`)
+- `failure_url` — where to send them if payment fails (e.g. `https://yourapp.com/callbacks/payment-failed`)
+- `redirect_to` — set to `"return_url"` so the customer lands back on your site instead of staying in the Credyt billing portal (this is the default, but set it explicitly)
+
 When the response status is `pending`:
 - Check the `required_actions` array for an action with `type: "payment"` and extract its `redirect_url`
-- Redirect the customer to that URL so they can enter their card details — include a `return_url` (where to send them on success) and a `failure_url` (where to send them if payment fails)
+- Redirect the customer to that URL — Credyt will handle the payment form and route them to your `return_url` or `failure_url` automatically
 - Do not activate the user's account yet — store it as pending in your database until payment is confirmed
 - If the redirect link expires before the customer completes payment, fetch the customer by their Credyt ID to get a refreshed link
 

--- a/skills/billing-setup/SKILL.md
+++ b/skills/billing-setup/SKILL.md
@@ -151,18 +151,23 @@ If the simulation doesn't match, create a new product version with `credyt:creat
 
 If the billing model includes credits bundled into a subscription (e.g., "$20/month includes 1,000 credits"), those are configured as **entitlements** at the product level — not as a negative price or a separate product.
 
-Include an `entitlements` array in the `create_product` (or `create_product_version`) call. For example, a product that grants 1,000 credits per day:
+Include an `entitlements` array in the `create_product` (or `create_product_version`) call. Entitlements have two modes:
+
+**Recurring** — credits refresh on a schedule (e.g., 1,000 credits every month):
 
 ```json
 "entitlements": [
   {
-    "name": "Daily Credit Allowance",
+    "name": "Monthly Credit Allowance",
     "asset": "{assetCode}",
     "amount": 1000,
     "purpose": "bundled",
-    "refresh": {
-      "interval": "day",
-      "strategy": "expire_and_replace"
+    "lifecycle": {
+      "duration": "month",
+      "duration_count": 1,
+      "refresh": {
+        "strategy": "expire_and_replace"
+      }
     },
     "accounting": {
       "revenue_basis": 0.00,
@@ -172,7 +177,30 @@ Include an `entitlements` array in the `create_product` (or `create_product_vers
 ]
 ```
 
-Confirm the entitlement fields (name, asset, amount, refresh interval) with the user before creating, using the standard parameter table.
+**One-off** — credits granted once and never refreshed (e.g., a sign-up bonus or promotional grant). Omit `lifecycle.refresh`:
+
+```json
+"entitlements": [
+  {
+    "name": "Welcome Bonus",
+    "asset": "{assetCode}",
+    "amount": 500,
+    "purpose": "promotion",
+    "lifecycle": {
+      "duration": "month",
+      "duration_count": 1
+    },
+    "accounting": {
+      "revenue_basis": 0.00,
+      "cost_basis": "auto"
+    }
+  }
+]
+```
+
+`lifecycle.duration` sets the expiry window; `duration_count` multiplies it (e.g., `duration: "month", duration_count: 3` expires after 3 months). `purpose` is `"bundled"` for subscription-included credits and `"promotion"` for one-off grants.
+
+Confirm the entitlement fields (name, asset, amount, lifecycle duration, and whether it refreshes) with the user before creating, using the standard parameter table.
 
 Do not attempt to model included credits as a negative fixed price — this fails validation and isn't the correct approach.
 


### PR DESCRIPTION
## What changed

**Entitlements schema** (`billing-setup/SKILL.md`)

Updated to match the new API structure:
- Replaced top-level `refresh` with `lifecycle` (required), containing `duration` (was `refresh.interval`), optional `duration_count`, and optional `lifecycle.refresh`
- `lifecycle.refresh` now only holds `strategy` — no `interval` nested inside
- Added explicit guidance for **one-off entitlements**: omit `lifecycle.refresh` and credits expire after the duration without renewing
- `purpose` documented as `"bundled"` (subscription-included) or `"promotion"` (one-off grants)
- Added `duration_count` explanation for multi-period expiry windows

**Fixed fee subscription redirects** (`billing-integration/SKILL.md`)

Added clear guidance that `return_url`, `failure_url`, and `redirect_to` must be set on the subscription creation call, not wired in after the fact:
- `return_url` — where to send the customer after successful payment
- `failure_url` — where to send them on failure
- `redirect_to: "return_url"` — ensures the customer lands back on the platform site, not the Credyt billing portal

**Plugin version** bumped `1.1.0` → `1.2.0` in both `plugin.json` files.

## How to test

1. `claude --plugin-dir ./claude-plugins/credyt`
2. Run `/credyt:billing-setup` with a hybrid subscription — verify the `create_product` call uses the new `lifecycle` structure
3. Configure a one-off promotional entitlement — confirm `lifecycle.refresh` is omitted
4. Run `/credyt:billing-integration` with a fixed fee product — verify the generated code sets `return_url`, `failure_url`, and `redirect_to` on the subscription creation call

## Trade-offs

Only the two skill files and plugin metadata changed — no other skills reference entitlement structure or fixed fee redirect behaviour directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)