### PR TITLE
feat: explicit billing-integration handoff in billing-setup

### DIFF
--- a/skills/billing-integration/SKILL.md
+++ b/skills/billing-integration/SKILL.md
@@ -5,6 +5,8 @@ description: Wire Credyt billing into your application code. Adds customer creat
 
 # Credyt Integrate
 
+> **This is the only supported way to wire Credyt into application code.** Do not hand-roll `fetch` calls, invent API endpoints, or guess authentication headers — use the SDK (`@credyt/api-client` for TypeScript, `credyt-api` for Python). If you arrived here without running `billing-setup` first, stop and ask the user to run that skill before proceeding.
+
 Help the user wire Credyt into their application code. This skill works with the user's actual codebase — reading their existing code and adding Credyt integration in the right places.
 
 The full integration guide is at [docs.credyt.ai/ai-integration.md](https://docs.credyt.ai/ai-integration.md). Each section below links to its dedicated docs page, which includes HTTP, TypeScript, and Python examples — consult these if you need more detail on any integration area.

--- a/skills/billing-integration/SKILL.md
+++ b/skills/billing-integration/SKILL.md
@@ -5,7 +5,7 @@ description: Wire Credyt billing into your application code. Adds customer creat
 
 # Credyt Integrate
 
-> **This is the only supported way to wire Credyt into application code.** Do not hand-roll `fetch` calls, invent API endpoints, or guess authentication headers — use the SDK (`@credyt/api-client` for TypeScript, `credyt-api` for Python). If you arrived here without running `billing-setup` first, stop and ask the user to run that skill before proceeding.
+> **Prefer the official SDKs** (`@credyt/api-client` for TypeScript, `credyt-api` for Python) over hand-rolling HTTP calls — they handle auth, retries, and field mapping for you. If neither SDK suits your stack (e.g. a language other than TypeScript or Python), HTTP direct calls are also covered below. If you arrived here without running `billing-setup` first, stop and ask the user to run that skill before proceeding.
 
 Help the user wire Credyt into their application code. This skill works with the user's actual codebase — reading their existing code and adding Credyt integration in the right places.
 

--- a/skills/billing-setup/SKILL.md
+++ b/skills/billing-setup/SKILL.md
@@ -251,4 +251,4 @@ Run the `billing-integration` skill next. If it is not installed, ask the user t
 
 If the skill is not available and the user has not explicitly asked you to write integration code, stop here and wait for them to install it. Do not hand-roll fetch calls or invent API endpoints.
 
-The SDK packages are `@credyt/api-client` (TypeScript/Node.js) and `credyt-api` (Python). These are the only supported ways to call the Credyt API from application code.
+The preferred way to call the Credyt API from application code is via one of the official SDKs: `@credyt/api-client` (TypeScript/Node.js) or `credyt-api` (Python). If neither SDK suits your stack, the billing-integration skill also covers HTTP direct calls.

--- a/skills/billing-setup/SKILL.md
+++ b/skills/billing-setup/SKILL.md
@@ -240,3 +240,15 @@ Summarize what was created and verified, then suggest next steps:
 > - [List vendors if created]
 >
 > Run `/credyt:billing-integration` when you're ready to wire this into your app, or `/credyt:billing-setup` again to add more products."
+
+## Next step
+
+This skill only configures products and pricing. Do not write integration code yourself — SDK shapes, endpoints, and auth headers are easy to guess wrong.
+
+Run the `billing-integration` skill next. If it is not installed, ask the user to install it:
+
+> "Run `npx skills add credyt/ai-tools`, then ask me to run the billing-integration skill."
+
+If the skill is not available and the user has not explicitly asked you to write integration code, stop here and wait for them to install it. Do not hand-roll fetch calls or invent API endpoints.
+
+The SDK packages are `@credyt/api-client` (TypeScript/Node.js) and `credyt-api` (Python). These are the only supported ways to call the Credyt API from application code.


### PR DESCRIPTION
Prevents agents from improvising integration code after setup completes.

Adds a "Next step" section to billing-setup that prohibits hand-rolling SDK calls and names the billing-integration skill as the required successor. Adds a canonical-path notice at the top of billing-integration so even agents that arrive there directly get the same signal.

Closes #55

Generated with [Claude Code](https://claude.ai/code)